### PR TITLE
Feat/#21 pay logic api

### DIFF
--- a/LetsBasketball.xcodeproj/project.pbxproj
+++ b/LetsBasketball.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		012C427D2C87416A00C78861 /* iamport-ios in Frameworks */ = {isa = PBXBuildFile; productRef = 012C427C2C87416A00C78861 /* iamport-ios */; };
+		012C42842C8859AA00C78861 /* PayValidationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 012C42832C8859AA00C78861 /* PayValidationModel.swift */; };
+		012C42862C885C9600C78861 /* PayValidationQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 012C42852C885C9600C78861 /* PayValidationQuery.swift */; };
 		01D112542C747554006B20BB /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D112532C747554006B20BB /* NetworkManager.swift */; };
 		01D112732C7610A5006B20BB /* Tabman in Frameworks */ = {isa = PBXBuildFile; productRef = 01D112722C7610A5006B20BB /* Tabman */; };
 		01D1127C2C771D2C006B20BB /* LBRequestInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D1127B2C771D2C006B20BB /* LBRequestInterceptor.swift */; };
@@ -95,6 +97,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		012C42832C8859AA00C78861 /* PayValidationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayValidationModel.swift; sourceTree = "<group>"; };
+		012C42852C885C9600C78861 /* PayValidationQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayValidationQuery.swift; sourceTree = "<group>"; };
 		01D112532C747554006B20BB /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		01D1127B2C771D2C006B20BB /* LBRequestInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LBRequestInterceptor.swift; sourceTree = "<group>"; };
 		01D1127F2C776E4F006B20BB /* BaseTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTableViewCell.swift; sourceTree = "<group>"; };
@@ -195,6 +199,31 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		012C42802C88597900C78861 /* Iamport */ = {
+			isa = PBXGroup;
+			children = (
+				012C42822C88598D00C78861 /* ResponseDTO */,
+				012C42812C88598700C78861 /* RequestDTO */,
+			);
+			path = Iamport;
+			sourceTree = "<group>";
+		};
+		012C42812C88598700C78861 /* RequestDTO */ = {
+			isa = PBXGroup;
+			children = (
+				012C42852C885C9600C78861 /* PayValidationQuery.swift */,
+			);
+			path = RequestDTO;
+			sourceTree = "<group>";
+		};
+		012C42822C88598D00C78861 /* ResponseDTO */ = {
+			isa = PBXGroup;
+			children = (
+				012C42832C8859AA00C78861 /* PayValidationModel.swift */,
+			);
+			path = ResponseDTO;
+			sourceTree = "<group>";
+		};
 		01D112832C78A81E006B20BB /* Yanong */ = {
 			isa = PBXGroup;
 			children = (
@@ -389,6 +418,7 @@
 		01E409562C6CE3DB0006B86F /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				012C42802C88597900C78861 /* Iamport */,
 				01D112D42C7E2CA7006B20BB /* KakaoAddress */,
 				01D112842C78A850006B20BB /* Refresh */,
 				01D112832C78A81E006B20BB /* Yanong */,
@@ -699,6 +729,7 @@
 				01E409B42C735C140006B86F /* FavoriteViewController.swift in Sources */,
 				01E409812C7079C30006B86F /* Router.swift in Sources */,
 				01E409B62C735C280006B86F /* ProfileViewController.swift in Sources */,
+				012C42862C885C9600C78861 /* PayValidationQuery.swift in Sources */,
 				01E409242C6CD0C60006B86F /* AppDelegate.swift in Sources */,
 				01D112F02C80AD05006B20BB /* LikePostModel.swift in Sources */,
 				01E409482C6CDD020006B86F /* APIKey.swift in Sources */,
@@ -709,6 +740,7 @@
 				01D1132E2C82EC55006B20BB /* RealmManager.swift in Sources */,
 				01D112A32C7B4F61006B20BB /* DetailYanongView.swift in Sources */,
 				01E409A72C7325010006B86F /* LBSearchView.swift in Sources */,
+				012C42842C8859AA00C78861 /* PayValidationModel.swift in Sources */,
 				01E409262C6CD0C60006B86F /* SceneDelegate.swift in Sources */,
 				01E409AB2C73449D0006B86F /* RecentCollectionViewCell.swift in Sources */,
 				01E4097D2C6DECE10006B86F /* JoinViewController.swift in Sources */,

--- a/LetsBasketball.xcodeproj/project.pbxproj
+++ b/LetsBasketball.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		012C427D2C87416A00C78861 /* iamport-ios in Frameworks */ = {isa = PBXBuildFile; productRef = 012C427C2C87416A00C78861 /* iamport-ios */; };
 		01D112542C747554006B20BB /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D112532C747554006B20BB /* NetworkManager.swift */; };
 		01D112732C7610A5006B20BB /* Tabman in Frameworks */ = {isa = PBXBuildFile; productRef = 01D112722C7610A5006B20BB /* Tabman */; };
 		01D1127C2C771D2C006B20BB /* LBRequestInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D1127B2C771D2C006B20BB /* LBRequestInterceptor.swift */; };
@@ -179,6 +180,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				012C427D2C87416A00C78861 /* iamport-ios in Frameworks */,
 				01D113282C82E954006B20BB /* RealmSwift in Frameworks */,
 				01E409412C6CD6EC0006B86F /* RxCocoa in Frameworks */,
 				01E4093E2C6CD6D60006B86F /* Kingfisher in Frameworks */,
@@ -574,6 +576,7 @@
 				01D112722C7610A5006B20BB /* Tabman */,
 				01D112B42C7C98B0006B20BB /* KakaoMapsSDK-SPM */,
 				01D113272C82E954006B20BB /* RealmSwift */,
+				012C427C2C87416A00C78861 /* iamport-ios */,
 			);
 			productName = LetsBasketball;
 			productReference = 01E409202C6CD0C60006B86F /* LetsBasketball.app */;
@@ -611,6 +614,7 @@
 				01D112712C7610A5006B20BB /* XCRemoteSwiftPackageReference "Tabman" */,
 				01D112B32C7C98B0006B20BB /* XCRemoteSwiftPackageReference "KakaoMapsSDK-SPM" */,
 				01D113262C82E954006B20BB /* XCRemoteSwiftPackageReference "realm-swift" */,
+				012C427B2C87416A00C78861 /* XCRemoteSwiftPackageReference "iamport-ios" */,
 			);
 			productRefGroup = 01E409212C6CD0C60006B86F /* Products */;
 			projectDirPath = "";
@@ -858,10 +862,12 @@
 				DEVELOPMENT_TEAM = 7S6PH8TVFD;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = LetsBasketball/Info.plist;
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "앱 사용 시 위치 접근을 허용해 주세요.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -891,10 +897,12 @@
 				DEVELOPMENT_TEAM = 7S6PH8TVFD;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = LetsBasketball/Info.plist;
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "앱 사용 시 위치 접근을 허용해 주세요.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -938,6 +946,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		012C427B2C87416A00C78861 /* XCRemoteSwiftPackageReference "iamport-ios" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/iamport/iamport-ios.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.4.2;
+			};
+		};
 		01D112712C7610A5006B20BB /* XCRemoteSwiftPackageReference "Tabman" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/uias/Tabman.git";
@@ -959,7 +975,7 @@
 			repositoryURL = "https://github.com/realm/realm-swift.git";
 			requirement = {
 				kind = exactVersion;
-				version = 10.51.0;
+				version = 10.49.0;
 			};
 		};
 		01E409392C6CD6CC0006B86F /* XCRemoteSwiftPackageReference "Alamofire" */ = {
@@ -997,6 +1013,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		012C427C2C87416A00C78861 /* iamport-ios */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 012C427B2C87416A00C78861 /* XCRemoteSwiftPackageReference "iamport-ios" */;
+			productName = "iamport-ios";
+		};
 		01D112722C7610A5006B20BB /* Tabman */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 01D112712C7610A5006B20BB /* XCRemoteSwiftPackageReference "Tabman" */;

--- a/LetsBasketball/Info.plist
+++ b/LetsBasketball/Info.plist
@@ -2,13 +2,60 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>앱 사용 시 위치 접근을 허용해 주세요.</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>slp.example</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>sesac</string>
+			</array>
+		</dict>
+	</array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kftc-bankpay</string>
+		<string>ispmobile</string>
+		<string>itms-apps</string>
+		<string>hdcardappcardansimclick</string>
+		<string>smhyundaiansimclick</string>
+		<string>shinhan-sr-ansimclick</string>
+		<string>smshinhanansimclick</string>
+		<string>kb-acp</string>
+		<string>mpocket.online.ansimclick</string>
+		<string>ansimclickscard</string>
+		<string>ansimclickipcollect</string>
+		<string>vguardstart</string>
+		<string>samsungpay</string>
+		<string>scardcertiapp</string>
+		<string>lottesmartpay</string>
+		<string>lotteappcard</string>
+		<string>cloudpay</string>
+		<string>nhappcardansimclick</string>
+		<string>nonghyupcardansimclick</string>
+		<string>citispay</string>
+		<string>citicardappkr</string>
+		<string>citimobileapp</string>
+		<string>kakaotalk</string>
+		<string>payco</string>
+		<string>chaipayment</string>
+		<string>kb-auth</string>
+		<string>hyundaicardappcardid</string>
+		<string>com.wooricard.wcard</string>
+		<string>lmslpay</string>
+		<string>lguthepay-xpay</string>
+		<string>liivbank</string>
+		<string>supertoss</string>
+		<string>newsmartpib</string>
+	</array>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Pretendard-Black.ttf</string>
@@ -18,8 +65,6 @@
 		<string>Pretendard-Regular.ttf</string>
 		<string>Pretendard-SemiBold.ttf</string>
 	</array>
-	<key>UIUserInterfaceStyle</key>
-	<string>Light</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/LetsBasketball/Source/Application/AppDelegate.swift
+++ b/LetsBasketball/Source/Application/AppDelegate.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import KakaoMapsSDK
+import iamport_ios
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -15,6 +16,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         SDKInitializer.InitSDK(appKey: APIKey.kakaoAppKey)
         
+        return true
+    }
+    
+    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+        Iamport.shared.receivedURL(url)
         return true
     }
 

--- a/LetsBasketball/Source/Network/Base/NetworkManager.swift
+++ b/LetsBasketball/Source/Network/Base/NetworkManager.swift
@@ -258,4 +258,31 @@ final class NetworkManager {
             return Disposables.create()
         }
     }
+    
+    // MARK: 결제 영수증 검증
+    func payValidation(imp_uid: String, post_id: String) -> Observable<PayValidationModel> {
+        return Observable.create { observer in
+            do {
+                let query = PayValidationQuery(imp_uid: imp_uid, post_id: post_id)
+                let request = try Router.payValidation(query: query).asURLRequest()
+                
+                AF.request(request)
+                    .responseDecodable(of: PayValidationModel.self) { response in
+                        switch response.result {
+                        case .success(let success):
+                            print(success)
+                            observer.onNext(success)
+                            observer.onCompleted()
+                            
+                        case .failure(let failure):
+                            print(failure)
+                            observer.onError(failure)
+                        }
+                    }
+            } catch {
+                observer.onError(error)
+            }
+            return Disposables.create()
+        }
+    }
 }

--- a/LetsBasketball/Source/Network/Base/Router.swift
+++ b/LetsBasketball/Source/Network/Base/Router.swift
@@ -16,6 +16,7 @@ enum Router {
     case postYanong(query: PostYanongQuery)
     case likePost(post_id: String, query: LikePostQuery)
     case fetchLikePost
+    case payValidation(query: PayValidationQuery)
 }
 
 extension Router: TargetType {
@@ -35,6 +36,8 @@ extension Router: TargetType {
             return .post
         case .fetchLikePost:
             return .get
+        case .payValidation:
+            return .post
         }
     }
     
@@ -65,6 +68,9 @@ extension Router: TargetType {
         case .likePost(_, let query):
             let encoder = JSONEncoder()
             return try? encoder.encode(query)
+        case .payValidation(let query):
+            let encoder = JSONEncoder()
+            return try? encoder.encode(query)
         default:
             return nil
         }
@@ -90,6 +96,8 @@ extension Router: TargetType {
             return "/posts/\(post_id)/like"
         case .fetchLikePost:
             return "/posts/likes/me"
+        case .payValidation:
+            return "/payments/validation"
         }
     }
     
@@ -134,6 +142,13 @@ extension Router: TargetType {
                 Header.sesacKey.rawValue: APIKey.key
             ]
         case .fetchLikePost:
+            return [
+                Header.authorization.rawValue: UserDefaultsManager.shared.token,
+                Header.contentType.rawValue: Header.json.rawValue,
+                Header.refresh.rawValue: UserDefaultsManager.shared.refreshToken,
+                Header.sesacKey.rawValue: APIKey.key
+            ]
+        case .payValidation:
             return [
                 Header.authorization.rawValue: UserDefaultsManager.shared.token,
                 Header.contentType.rawValue: Header.json.rawValue,

--- a/LetsBasketball/Source/Network/Iamport/RequestDTO/PayValidationQuery.swift
+++ b/LetsBasketball/Source/Network/Iamport/RequestDTO/PayValidationQuery.swift
@@ -1,0 +1,13 @@
+//
+//  PayValidationQuery.swift
+//  LetsBasketball
+//
+//  Created by 강석호 on 9/4/24.
+//
+
+import Foundation
+
+struct PayValidationQuery: Encodable {
+    let imp_uid: String
+    let post_id: String
+}

--- a/LetsBasketball/Source/Network/Iamport/ResponseDTO/PayValidationModel.swift
+++ b/LetsBasketball/Source/Network/Iamport/ResponseDTO/PayValidationModel.swift
@@ -1,0 +1,18 @@
+//
+//  PayDTO.swift
+//  LetsBasketball
+//
+//  Created by 강석호 on 9/4/24.
+//
+
+import Foundation
+import Alamofire
+
+struct PayValidationModel: Decodable {
+    let buyer_id: String
+    let post_id: String
+    let merchant_uid: String
+    let productName: String
+    let price: Int
+    let paidAt: String
+}

--- a/LetsBasketball/Source/Presentation/Home/Yanong/DetailYanong/DetailYanongView.swift
+++ b/LetsBasketball/Source/Presentation/Home/Yanong/DetailYanong/DetailYanongView.swift
@@ -17,6 +17,7 @@ final class DetailYanongView: BaseView {
     let regionLabel = UILabel()
     let mapThumbnail = UIImageView()
     let mapButton = UIButton()
+    let payButton = UIButton()
     
     override func configureHierarchy() {
         addSubview(titleLabel)
@@ -26,6 +27,7 @@ final class DetailYanongView: BaseView {
         regionView.addSubview(regionLabel)
         addSubview(mapThumbnail)
         mapThumbnail.addSubview(mapButton)
+        addSubview(payButton)
     }
     
     override func configureUI() {
@@ -54,6 +56,12 @@ final class DetailYanongView: BaseView {
         mapThumbnail.isUserInteractionEnabled = true
         
         mapButton.backgroundColor = .clear
+        
+        payButton.setTitle("신청하기", for: .normal)
+        payButton.setTitleColor(.white, for: .normal)
+        payButton.titleLabel?.font = UIFont(name: "Pretendard-SemiBold", size: 17)
+        payButton.backgroundColor = UIColor(named: "BaseColor")
+        payButton.layer.cornerRadius = 10
     }
     
     override func configureConstraints() {
@@ -82,6 +90,11 @@ final class DetailYanongView: BaseView {
         }
         mapButton.snp.makeConstraints { make in
             make.edges.equalToSuperview()
+        }
+        payButton.snp.makeConstraints { make in
+            make.bottom.equalToSuperview().inset(80)
+            make.horizontalEdges.equalToSuperview().inset(20)
+            make.height.equalTo(48)
         }
     }
 }


### PR DESCRIPTION
## 📝작업 내용

### PG 결제 기능 추가

IamPort API(구 PortOne (포트원)) 를 활용하여 결제기능을 구현하였습니다.


```
Iamport.shared.paymentWebView(
            webViewMode: wkWebView,
            userCode: APIKey.iamportUserCode,
            payment: payment) { [weak self] response in
                print(String(describing: response))
                
                let uid = response?.imp_uid ?? ""
                let post_id = self?.viewModel.post_id ?? ""
                
                NetworkManager.shared.payValidation(imp_uid: uid, post_id: post_id)
                    .subscribe(onNext: { valid in
                        self?.showAlert(title: "결제 성공")
                    }, onError: { error in
                        self?.showAlert(title: "결제 실패")
                    })
                    .disposed(by: self!.disposeBag)
            }

```


### 스크린샷(선택)
